### PR TITLE
Improve block.json validation before block registration

### DIFF
--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -60,7 +60,7 @@ function bigboost_register_blocks() {
             }
         }
 
-        if (!empty($data['acf']) && isset($data['acf']['renderTemplate'])) {
+        if (isset($data['acf']) && isset($data['acf']['renderTemplate'])) {
             // Include render template path check as part of validation
             if (!is_string($data['acf']['renderTemplate']) || $data['acf']['renderTemplate'] === '') {
                 $missing[] = 'acf.renderTemplate';


### PR DESCRIPTION
## Summary
- add validation for block metadata before calling `register_block_type`

## Testing
- `php -l acf-custom-blocks.php`


------
https://chatgpt.com/codex/tasks/task_e_688330011e5483258ba92a3e52b5c881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error handling during block registration to prevent invalid or incomplete blocks from being registered.

* **Chores**
  * Enhanced error reporting for issues found in block configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->