### PR TITLE
Fix CSS clash by prefixing block classes

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -75,7 +75,7 @@ a {
     text-decoration: none !important;
     color: inherit;
 }
-.downarrow{
+.bb-downarrow{
 	cursor:pointer;
 }
 .site-header {
@@ -263,40 +263,40 @@ a {
     margin: 0 auto;
 }
 
-.faq-section {
+.bb-faq-section {
     padding: 100px 0;
 }
 
-.faq-section>div>span {
+.bb-faq-section>div>span {
     font-weight: 700;
     font-size: 28px;
     font-family: 'GoFundMe';
 }
 
-.faq-section .faq-title {
+.bb-faq-section .bb-faq-title {
     margin-top: 64px;
 }
 
-.faq-section .faq-title>div {
+.bb-faq-section .bb-faq-title>div {
     border-bottom: 1px solid #D8D8D8;
 }
 
-.faq-section .faq-title>div:not(:last-child) {
+.bb-faq-section .bb-faq-title>div:not(:last-child) {
     margin-bottom: 32px;
 }
 
-.faq-section .faq-title>div>div:first-child {
+.bb-faq-section .bb-faq-title>div>div:first-child {
     margin-bottom: 24px;
 }
 
-.faq-section .faq-title h2 {
+.bb-faq-section .bb-faq-title h2 {
     color: var(--primary);
     font-weight: 700;
     font-size: 40px;
     font-family: 'GoFundMe';
 }
 
-.faq-section .faq-title p {
+.bb-faq-section .bb-faq-title p {
     font-weight: 400;
     font-size: 24px;
     font-family: 'GoFundMe';
@@ -355,79 +355,79 @@ a {
     color: var(--yellow);
 }
 
-.faq-title h2 {
+.bb-faq-title h2 {
     color: #333333 !important;
 }
 
-.faq-title h2 a {
+.bb-faq-title h2 a {
     color: #333333 !important;
     text-decoration: underline !important;
 }
 
-.faq-title .description {
+.bb-faq-title .bb-faq-description {
     display: none;
     color: #6F6F6F;
 }
 
-.faq-title .description a {
+.bb-faq-title .bb-faq-description a {
     color: #6F6F6F;
     text-decoration: underline !important;
 }
 
-.circle-slider {
+.bb-circle-slider {
     background-color: var(--background);
 }
 
-.circle-slider .slider-content {
+.bb-circle-slider .bb-slider-content {
     width: 80%;
     padding: 115px 0;
 }
 
 @media (max-width: 992px) {
-    .circle-slider .slider-content img {
+    .bb-circle-slider .bb-slider-content img {
         max-width: 100%;
         height: auto;
     }
 }
 
-.circle-slider .slider-content * {
+.bb-circle-slider .bb-slider-content * {
     color: var(--white);
 }
 
-.circle-slider .slider-content h2 {
+.bb-circle-slider .bb-slider-content h2 {
     margin-top: 16px;
     font-weight: 700;
     font-size: 40px !important;
     font-family: 'GoFundMe';
 }
 
-.circle-slider .slider-content>p {
+.bb-circle-slider .bb-slider-content>p {
     margin-top: 16px;
     font-size: 14px !important;
     font-weight: 400;
     font-family: 'GoFundMe';
 }
 
-.circle-slider .slider-content .border-view {
+.bb-circle-slider .bb-slider-content .bb-border-view {
     color: var(--yellow);
     border: 1px solid var(--yellow);
     border-radius: 100px;
     padding: 1.5px 8px;
 }
 
-.circle-slider .slider-content .slider-context .slider-actions {
+.bb-circle-slider .bb-slider-content .bb-slider-context .bb-slider-actions {
     margin-bottom: 8px;
 }
 
-.circle-slider .slider-content .slider-context {
+.bb-circle-slider .bb-slider-content .bb-slider-context {
     margin-top: 30px;
 }
 
-.circle-slider .slider-content .slider-context>div {
+.bb-circle-slider .bb-slider-content .bb-slider-context>div {
     margin-top: 42px;
 }
 
-.circle-slider .slider-content .slider-context>div .cirle-outline {
+.bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline {
     border: 2px solid var(--white);
     width: 50px;
     height: 50px;
@@ -437,7 +437,7 @@ a {
     position: relative;
 }
 
-.circle-slider .slider-content .slider-context>div .cirle-outline span {
+.bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline span {
     position: absolute;
     top: 50%;
     left: 50%;
@@ -445,18 +445,18 @@ a {
 
 }
 
-.circle-slider .slider-content .slider-context>div.active .cirle-outline {
+.bb-circle-slider .bb-slider-content .bb-slider-context>div.active .bb-circle-outline {
     border: 2px solid var(--yellow);
 }
 
 @media (max-width: 992px) {
-    .circle-slider .slider-content .slider-context>div .cirle-outline {
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline {
         width: 32px;
         height: 32px;
     }
 }
 
-.circle-slider .slider-content .slider-context>div h3 {
+.bb-circle-slider .bb-slider-content .bb-slider-context>div h3 {
     margin-bottom: 0;
     margin-left: 14px;
     font-weight: 700;
@@ -464,24 +464,24 @@ a {
     font-family: 'GoFundMe';
 }
 
-.circle-slider .slider-content .slider-context>div .description {
+.bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-slider-description {
     margin-left: 64px;
     display: none;
 }
 
-.circle-slider .slider-images {
+.bb-circle-slider .bb-slider-images {
     overflow: hidden;
     position: relative;
 }
 
-.circle-slider .slider-images .slider-item {
+.bb-circle-slider .bb-slider-images .bb-slider-item {
     position: absolute;
     height: 100%;
     width: 100%;
     transition: all 0.3s ease;
 }
 
-.circle-slider .slider-images .slider-item>div {
+.bb-circle-slider .bb-slider-images .bb-slider-item>div {
     transition: all 0.3s ease;
     position: absolute;
     top: 50%;
@@ -491,54 +491,54 @@ a {
     transform: translate(-15%, -50%);
 }
 
-.circle-slider .slider-images .slider-item>div .big-img {
+.bb-circle-slider .bb-slider-images .bb-slider-item>div .bb-big-img {
     position: relative;
     height: 100%;
     width: fit-content;
 }
 
-.circle-slider .slider-images .slider-item>div .ui-img {
+.bb-circle-slider .bb-slider-images .bb-slider-item>div .bb-ui-img {
     height: 60%;
     position: absolute;
     bottom: 24px;
     left: -130px;
 }
 
-.circle-slider .slider-images .slider-item.active {
+.bb-circle-slider .bb-slider-images .bb-slider-item.active {
     top: 0%;
     left: 0%;
     transform: rotate(0deg);
 }
 
-.circle-slider .slider-images .slider-item.active>div {
+.bb-circle-slider .bb-slider-images .bb-slider-item.active>div {
     transform: translate(-15%, -50%) scale(1.5);
 }
 
-.circle-slider .slider-images .slider-item.next {
+.bb-circle-slider .bb-slider-images .bb-slider-item.next {
     top: 67%;
     left: 160px;
     transform: rotate(-28deg);
 }
 
-.circle-slider .slider-images .slider-item.previous {
+.bb-circle-slider .bb-slider-images .bb-slider-item.previous {
     top: -68%;
     left: 160px;
     transform: rotate(28deg);
 }
 
-.circle-slider .slider-images .slider-item.next-next {
+.bb-circle-slider .bb-slider-images .bb-slider-item.next-next {
     top: 100%;
     left: 0;
     transform: rotate(-48deg);
 }
 
-.circle-slider .slider-images .slider-item.pre-pre {
+.bb-circle-slider .bb-slider-images .bb-slider-item.pre-pre {
     top: -100%;
     left: 0px;
     transform: rotate(48deg);
 }
 
-.circle-slider .slider-images .slider-item img {
+.bb-circle-slider .bb-slider-images .bb-slider-item img {
     height: 100%;
     width: 100%;
     object-fit: contain;
@@ -565,26 +565,26 @@ a {
         font-size: 14px !important;
     }
 
-    .circle-slider .slider-content {
+    .bb-circle-slider .bb-slider-content {
         width: 100%;
         padding: 48px 15px;
     }
 
-    .circle-slider .slider-content h2,
-    .circle-slider .slider-content>p {
+    .bb-circle-slider .bb-slider-content h2,
+    .bb-circle-slider .bb-slider-content>p {
         text-align: center;
     }
 
-    .circle-slider .slider-content p a {
+    .bb-circle-slider .bb-slider-content p a {
         text-decoration: underline !important;
     }
 
-    .circle-slider .slider-context p {
+    .bb-circle-slider .bb-slider-context p {
         font-size: 16px !important;
         font-weight: 400;
     }
 
-    .circle-slider .slider-content .slider-context>div .description {
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-slider-description {
         margin-left: 0px;
         display: none;
 
@@ -593,13 +593,13 @@ a {
         }
     }
 
-    .circle-slider .slider-content .slider-context>div {
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div {
         margin-top: 24px;
         padding-bottom: 8px;
         border-bottom: 1px solid #D8D8D8;
     }
 
-    .circle-slider .slider-content .slider-context>div:last-child {
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div:last-child {
         border-bottom: none;
     }
 
@@ -616,26 +616,26 @@ a {
         font-size: 18px !important;
 		 padding-bottom:20px !important;
     }
-    .faq-section>div>span {
+    .bb-faq-section>div>span {
         color: #232323;
         font-weight: 700;
         font-size: 24px;
         font-family: 'GoFundMe';
     }
 
-    .faq-title>div>div h2 {
+    .bb-faq-title>div>div h2 {
         width: calc(100% - 32px);
     }
 
-    .faq-section {
+    .bb-faq-section {
         padding: 40px 0;
     }
 
-    .faq-title>div>div:first-child {
+    .bb-faq-title>div>div:first-child {
         width: 100%;
     }
 
-    .faq-title>div>div:last-child img {
+    .bb-faq-title>div>div:last-child img {
         height: 24px;
         width: 24px;
     }

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,13 +1,13 @@
 $(document).ready(function () {
 
-    let height = $('.slider-content').outerHeight();
-    $('.slider-images').height(height);
+    let height = $('.bb-slider-content').outerHeight();
+    $('.bb-slider-images').height(height);
     let previousIndex = 0;
 
-    $('.slider-actions').on('click', function (e) {
+    $('.bb-slider-actions').on('click', function (e) {
         e.preventDefault();
-        const targetIndex = $('.slider-actions').index(this);
-        const items = $('.slider-item');
+        const targetIndex = $('.bb-slider-actions').index(this);
+        const items = $('.bb-slider-item');
 
         // Prevent multiple clicks during animation
         if (isAnimating) return;
@@ -28,7 +28,7 @@ $(document).ready(function () {
 
         function animateStep(currentIndex, targetIndex, isForward) {
             const classes = isForward ? clForward : clReverse;
-            $('.slider-item').removeClass('previous active next next-next pre-pre d-none');
+            $('.bb-slider-item').removeClass('previous active next next-next pre-pre d-none');
 
             for (let i = 0; i < classes[currentIndex]?.length; i++) {
                 $(items[i]).addClass(`${classes[currentIndex][i]}`)
@@ -62,8 +62,8 @@ $(document).ready(function () {
             function nextStep() {
                 if (current === target) {
                     previousIndex = target;
-                    $('.description').slideUp(300);
-                    $($('.slider-actions')[target]).closest('div').find('.description').slideToggle(300);
+                    $('.bb-slider-description').slideUp(300);
+                    $($('.bb-slider-actions')[target]).closest('div').find('.bb-slider-description').slideToggle(300);
                     isAnimating = false;
                     return;
                 }
@@ -82,32 +82,32 @@ $(document).ready(function () {
 
     });
 
-    $('.toggle-slider').on('click', function (e) {
+    $('.bb-toggle-slider').on('click', function (e) {
         e.preventDefault();
         if ($(this).closest('div').hasClass('active')) {
-            $('.slider-context > div').removeClass('active')
-            $(this).closest('div').find('.description').slideUp()
+            $('.bb-slider-context > div').removeClass('active')
+            $(this).closest('div').find('.bb-slider-description').slideUp()
         } else {
-            $('.slider-context > div').removeClass('active')
+            $('.bb-slider-context > div').removeClass('active')
             $(this).closest('div').addClass('active')
-            $('.description').slideUp()
-            $(this).closest('div').find('.description').slideToggle()
+            $('.bb-slider-description').slideUp()
+            $(this).closest('div').find('.bb-slider-description').slideToggle()
         }
     })
 
     // Initialize animation state
     let isAnimating = false;
 
-    $('.downarrow').on('click', function (e) {
+    $('.bb-downarrow').on('click', function (e) {
         e.preventDefault();
-        if ($(this).closest('.d-flex.justify-content-between').next('.description').hasClass('active')) {
-            $('.description').slideUp(100)
-            $(this).closest('.d-flex.justify-content-between').next('.description').removeClass('active')
+        if ($(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').hasClass('active')) {
+            $('.bb-faq-description').slideUp(100)
+            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').removeClass('active')
         } else {
-            $('.faq-title').find('.description').removeClass('active')
-            $('.description').slideUp(100)
-            $(this).closest('.d-flex.justify-content-between').next('.description').slideToggle(300)
-            $(this).closest('.d-flex.justify-content-between').next('.description').addClass('active')
+            $('.bb-faq-title').find('.bb-faq-description').removeClass('active')
+            $('.bb-faq-description').slideUp(100)
+            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').slideToggle(300)
+            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').addClass('active')
         }
 
     })

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -6,32 +6,32 @@ $section_tag = get_field('field_circle_slider_tag');
 $section_items = get_field('field_circle_slider_items');
 ?>
 <?php if ($section_items) : ?>
-    <section class="circle-slider d-none d-lg-block">
+    <section class="bb-circle-slider d-none d-lg-block">
         <div class="container">
             <div class="row">
                 <!-- Left Content -->
                 <div class="col-12 col-lg-5">
-                    <div class="slider-content">
+                    <div class="bb-slider-content">
                         <?php if ($section_tag) : ?>
-                            <span class="border-view"><?php echo esc_html($section_tag); ?></span>
+                            <span class="bb-border-view"><?php echo esc_html($section_tag); ?></span>
                         <?php endif; ?>
 
                         <?php if ($section_title) : ?>
                             <h2><?php echo esc_html($section_title); ?></h2>
                         <?php endif; ?>
 
-                        <div class="slider-context">
+                        <div class="bb-slider-context">
                             <?php foreach ($section_items as $index => $item) : ?>
                                 <div>
-                                    <a href="#" class="d-flex align-items-center slider-actions">
+                                    <a href="#" class="d-flex align-items-center bb-slider-actions">
                                         <div>
-                                            <div class="cirle-outline">
+                                            <div class="bb-circle-outline">
                                                 <span><?php echo esc_html($item['step_number']); ?></span>
                                             </div>
                                         </div>
                                         <h3><?php echo esc_html($item['step_title']); ?></h3>
                                     </a>
-                                    <div class="description" <?php echo ($index === 0) ? 'style="display: block;"' : ''; ?>>
+                                    <div class="bb-slider-description" <?php echo ($index === 0) ? 'style="display: block;"' : ''; ?>>
                                         <p><?php echo esc_html($item['step_description']); ?></p>
                                     </div>
                                 </div>
@@ -42,16 +42,16 @@ $section_items = get_field('field_circle_slider_items');
                 
                 <!-- Right Images -->
                 <div class="col-12 col-lg-7">
-                    <div class="slider-images">
+                    <div class="bb-slider-images">
                         <?php foreach ($section_items as $index => $item) : ?>
-                            <div class="slider-item <?php echo ($index === 0) ? 'active' : 'next'; ?>">
-                                <div class="big-img">
+                            <div class="bb-slider-item <?php echo ($index === 0) ? 'active' : 'next'; ?>">
+                                <div class="bb-big-img">
                                     <?php if (!empty($item['main_image'])) : ?>
                                         <img src="<?php echo esc_url($item['main_image']['url']); ?>" alt="">
                                     <?php endif; ?>
 
                                     <?php if (!empty($item['ui_image'])) : ?>
-                                        <div class="ui-img">
+                                        <div class="bb-ui-img">
                                             <img src="<?php echo esc_url($item['ui_image']['url']); ?>" alt="">
                                         </div>
                                     <?php endif; ?>
@@ -65,25 +65,25 @@ $section_items = get_field('field_circle_slider_items');
     </section>
 <?php endif; ?>
 <?php if ($section_items) : ?>
-	    <section class="circle-slider d-block d-lg-none">
+	    <section class="bb-circle-slider d-block d-lg-none">
             <div class="container">
                 <div class="row">
                     <div class="col-12">
-                        <div class="slider-content">
-                            <!-- <span class="border-view">Best practices</span> -->
+                        <div class="bb-slider-content">
+                            <!-- <span class="bb-border-view">Best practices</span> -->
                             <h2> <?php echo esc_html($section_title); ?> </h2>
-                           <div class="slider-context">
+                           <div class="bb-slider-context">
 								<?php foreach ($section_items as $index => $item) : ?>
                                 <div>
-                                    <a href="" class="d-flex align-items-center toggle-slider mb-3">
+                                    <a href="" class="d-flex align-items-center bb-toggle-slider mb-3">
                                         <div>
-                                            <div class="cirle-outline">
+                                            <div class="bb-circle-outline">
                                                 <span> <?php echo esc_html($item['step_number']); ?> </span>
                                             </div>
                                         </div>
                                         <h3><?php echo esc_html($item['step_title']); ?></h3>
                                     </a>
-                                    <div class="description">
+                                    <div class="bb-slider-description">
                                         <p>
                                            <?php echo esc_html($item['step_description']); ?>
                                         </p>

--- a/blocks/faq/faq.php
+++ b/blocks/faq/faq.php
@@ -4,15 +4,15 @@ $faq_description = get_field('faq_description');
 $faq_items = get_field('faq_items');
 ?>
 
-        <section class="faq-section">
+        <section class="bb-faq-section">
             <div class="container">
                 <span class="d-none d-lg-block"><?php echo esc_html($faq_title); ?></span>
                 <span class="d-block d-lg-none text-center"><?php echo esc_html($faq_title); ?></span>
-                <div class="faq-title">
+                <div class="bb-faq-title">
 					  <?php if ($faq_items): ?>
                 <?php foreach ($faq_items as $index => $faq): ?>
                     <div>
-                        <div class="d-flex justify-content-between align-items-lg-start align-items-center downarrow">
+                        <div class="d-flex justify-content-between align-items-lg-start align-items-center bb-downarrow">
                            <?php echo wp_kses_post($faq['question']); ?>
                             <div>
                                  <a href="">
@@ -21,7 +21,7 @@ $faq_items = get_field('faq_items');
                                 </a>
                             </div>
                         </div>
-                        <div class="description">
+                        <div class="bb-faq-description">
                             <p>
                                <?php echo wp_kses_post($faq['answer']); ?>
                             </p>


### PR DESCRIPTION
## Summary
- prefix circle-slider classes with `bb-`
- prefix FAQ classes with `bb-`
- update corresponding selectors in global styles and scripts
- use block-specific `bb-slider-description` and `bb-faq-description`

## Testing
- `php -l blocks/circle-slider/circle-slider.php`
- `php -l blocks/faq/faq.php`


------
https://chatgpt.com/codex/tasks/task_e_688461049bfc8325bd8369de96ff1fb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated all relevant CSS class names by adding a "bb-" prefix for improved namespacing.
* **Bug Fixes**
  * Adjusted interactive elements and event bindings to use the new "bb-" prefixed class names, ensuring consistent functionality.
* **Refactor**
  * Renamed class names in HTML templates to match the new "bb-" prefixed naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->