### PR TITLE
Fix circle slider interactivity

### DIFF
--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -17,9 +17,9 @@ function bigboost_enqueue_global_assets() {
 
     wp_enqueue_script('bootstrap-js', 'https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js', array('jquery'), null, true);
 
-    // Example: Swiper CSS & JS from CDN
-
-    wp_enqueue_script('jquery-js', 'https://code.jquery.com/jquery-3.6.4.min.js', array(), null, true);
+    // jQuery is bundled with WordPress so we rely on the core version to avoid
+    // loading it twice and potential conflicts.
+    wp_enqueue_script('jquery');
 
     // Example: Your plugin's custom CSS and JS (if you want)
     wp_enqueue_style('bigboost-global-css', plugin_dir_url(__FILE__) . 'assets/global.css');

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,4 +1,4 @@
-$(document).ready(function () {
+jQuery(function ($) {
 
     let height = $('.bb-slider-content').outerHeight();
     $('.bb-slider-images').height(height);


### PR DESCRIPTION
## Summary
- rely on WordPress core jQuery instead of loading a second copy
- wrap global JS in a jQuery no‑conflict friendly callback

## Testing
- `node -c assets/global.js`


------
https://chatgpt.com/codex/tasks/task_e_6884894ab32483259969faeae8d9b33c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility by switching to the WordPress bundled version of jQuery instead of loading it from an external source.
  * Updated jQuery initialization to ensure proper use of the `$` alias and prevent potential conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->