### PR TITLE
Fix quote layout and padding

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -585,7 +585,8 @@ a {
     }
 
     .bb-circle-slider .bb-slider-content h2,
-    .bb-circle-slider .bb-slider-content>p {
+    .bb-circle-slider .bb-slider-content > p,
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div h3 {
         text-align: center;
     }
 

--- a/assets/global.css
+++ b/assets/global.css
@@ -65,13 +65,14 @@ body {
     margin: 0;
 }
 
-.container {
+/* Custom container to avoid conflicts with framework CSS */
+.bb-container {
     padding-left: 10%;
     padding-right: 10%;
 }
 
 @media (max-width: 768px) {
-    .container {
+    .bb-container {
         padding-left: 5%;
         padding-right: 5%;
     }

--- a/assets/global.css
+++ b/assets/global.css
@@ -65,6 +65,18 @@ body {
     margin: 0;
 }
 
+.container {
+    padding-left: 10%;
+    padding-right: 10%;
+}
+
+@media (max-width: 768px) {
+    .container {
+        padding-left: 5%;
+        padding-right: 5%;
+    }
+}
+
 ul {
     list-style: none;
     padding: 0 !important;
@@ -236,7 +248,7 @@ a {
 }
 
 .quotes-section p img {
-    vertical-align: super;
+    vertical-align: baseline;
 }
 
 .quotes-blocks img {
@@ -462,6 +474,7 @@ a {
     font-weight: 700;
     font-size: 24px;
     font-family: 'GoFundMe';
+    text-align: left;
 }
 
 .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-slider-description {

--- a/blocks/banner-section/banner.php
+++ b/blocks/banner-section/banner.php
@@ -6,7 +6,7 @@ $button = get_field('button');
 $button_text = get_field('button_text');
 ?>
 <section class="hero-section position-relative" aria-labelledby="hero-heading">
-    <div class="container">
+    <div class="bb-container">
                 <?php if ($subheading): ?>
                     <span class="sub-title"><?php echo esc_html($subheading); ?></span>
                 <?php endif; ?>

--- a/blocks/call-to-action/cta.php
+++ b/blocks/call-to-action/cta.php
@@ -4,7 +4,7 @@ $description = get_field('field_cta_description');
 $button = get_field('cta_button');
 ?>
 <section class="survey">
-            <div class="container">
+            <div class="bb-container">
                 <h2><?php echo esc_html($title); ?></h2>
                 <p><?php echo esc_html($description); ?></p>
                 <a href="<?php echo esc_url($button['url']); ?>"><?php echo esc_html($button['title']); ?></a>

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -7,7 +7,7 @@ $section_items = get_field('field_circle_slider_items');
 ?>
 <?php if ($section_items) : ?>
     <section class="bb-circle-slider d-none d-lg-block">
-        <div class="container">
+        <div class="bb-container">
             <div class="row">
                 <!-- Left Content -->
                 <div class="col-12 col-lg-5">
@@ -71,7 +71,7 @@ $section_items = get_field('field_circle_slider_items');
 <?php endif; ?>
 <?php if ($section_items) : ?>
 	    <section class="bb-circle-slider d-block d-lg-none">
-            <div class="container">
+            <div class="bb-container">
                 <div class="row">
                     <div class="col-12">
                         <div class="bb-slider-content">

--- a/blocks/faq/faq.php
+++ b/blocks/faq/faq.php
@@ -5,7 +5,7 @@ $faq_items = get_field('faq_items');
 ?>
 
         <section class="bb-faq-section">
-            <div class="container">
+            <div class="bb-container">
                 <span class="d-none d-lg-block"><?php echo esc_html($faq_title); ?></span>
                 <span class="d-block d-lg-none text-center"><?php echo esc_html($faq_title); ?></span>
                 <div class="bb-faq-title">

--- a/blocks/quote-section/quote.php
+++ b/blocks/quote-section/quote.php
@@ -4,7 +4,7 @@ $author = get_field('field_author');
 $banner_image = get_field('banner_image')
 ?>
 <section class="quotes-section">
-    <div class="container">
+    <div class="bb-container">
 		<div class="row image-quote-block">
 			<div class="col-12 col-md-6 image-blocks">
 				<div class="hero-quote-img">


### PR DESCRIPTION
## Summary
- tweak quote image alignment
- ensure slider headings align left
- add responsive container padding

## Testing
- `php -l blocks/quote-section/quote.php`
- `php -l blocks/circle-slider/circle-slider.php`


------
https://chatgpt.com/codex/tasks/task_e_6884b949919483258592d0a36698ef7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Introduced a new responsive `.bb-container` class with adaptive horizontal padding.
  * Updated `.primary-button` and certain slider headings to align text to the left.
  * Adjusted image alignment within quotes sections for improved visual consistency.
  * Replaced existing container classes with the new `.bb-container` for consistent layout across multiple sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->