### PR TITLE
Fix quote image alignment

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -248,8 +248,15 @@ a {
     padding-bottom: 20px;
 }
 
-.quotes-section p img {
-    vertical-align: baseline;
+.quotes-section p.quote-line {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.quotes-section p.quote-line img {
+    display: inline-block;
+    vertical-align: middle;
 }
 
 .quotes-blocks img {

--- a/blocks/quote-section/quote.php
+++ b/blocks/quote-section/quote.php
@@ -1,7 +1,7 @@
 <?php
 $quote = get_field('field_quote');
 $author = get_field('field_author');
-$banner_image = get_field('banner_image')
+$banner_image = get_field('banner_image');
 ?>
 <section class="quotes-section">
     <div class="bb-container">
@@ -13,11 +13,11 @@ $banner_image = get_field('banner_image')
 			</div>
 			<div class="col-12 col-md-6 quotes-blocks">
 				<div>
-					 <p>
-						<img src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/start.png" alt="start-quotes">
-							<?php echo esc_html($quote); ?>
-						<img src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/end.png" alt="end-quotes">
-					</p>
+                                         <p class="quote-line">
+                                                <img src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/start.png" alt="start-quotes">
+                                                <?php echo esc_html($quote); ?>
+                                                <img src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/end.png" alt="end-quotes">
+                                         </p>
 					<span><?php echo esc_html($author); ?></span>
 				</div>
 			</div>


### PR DESCRIPTION
## Summary
- use a `quote-line` class to arrange the quote images inline with the text
- update CSS to flexibly align quote images and text

## Testing
- `php -l blocks/quote-section/quote.php`


------
https://chatgpt.com/codex/tasks/task_e_68850a2263308325991efb9ee3146063