### PR TITLE
Improve circle slider timing and visuals

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -543,7 +543,7 @@ a {
     bottom: 24px;
     left: -130px;
     transition: transform 0.5s ease;
-    transition-delay: 0.2s;
+    transition-delay: 0.5s;
     transform: translate(0,0) scale(1);
 }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -11,7 +11,7 @@ jQuery(function ($) {
         const circle = circles.eq(index);
         if(circle.length){
             circle[0].getBoundingClientRect();
-            circle.css({'transition':'stroke-dashoffset 5s linear','stroke-dashoffset':0});
+            circle.css({'transition':'stroke-dashoffset 7s linear','stroke-dashoffset':0});
         }
     }
 
@@ -24,7 +24,7 @@ jQuery(function ($) {
                 let next = (previousIndex + 1) % actions.length;
                 $(actions[next]).trigger('click');
             }
-        },5000);
+        },7000);
     }
 
     function stopAuto(){

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -28,8 +28,8 @@ $section_items = get_field('field_circle_slider_items');
 
                                         <div>
                                             <div class="bb-circle-outline">
-                                                <svg class="progress-ring" viewBox="0 0 36 36">
-                                                    <circle class="progress-ring__circle" cx="18" cy="18" r="16"></circle>
+                                                <svg class="progress-ring" viewBox="0 0 50 50">
+                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
                                                 </svg>
                                                 <span><?php echo esc_html($item['step_number']); ?></span>
                                             </div>
@@ -87,8 +87,8 @@ $section_items = get_field('field_circle_slider_items');
                                     <button type="button" class="d-flex align-items-center bb-toggle-slider mb-3">
                                         <div>
                                             <div class="bb-circle-outline">
-                                                <svg class="progress-ring" viewBox="0 0 36 36">
-                                                    <circle class="progress-ring__circle" cx="18" cy="18" r="16"></circle>
+                                                <svg class="progress-ring" viewBox="0 0 50 50">
+                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
                                                 </svg>
                                                 <span> <?php echo esc_html($item['step_number']); ?> </span>
                                             </div>


### PR DESCRIPTION
## Summary
- tweak slider SVG so timer ring overlays existing circle
- stagger big and UI image slide timing by increasing delay
- slow down autoplay timing to 7 seconds

## Testing
- `php -l blocks/circle-slider/circle-slider.php`

------
https://chatgpt.com/codex/tasks/task_e_6889ead291d88325949d62d9d00b87b4