### PR TITLE
Update FAQ icons and fix circle slider text alignment

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -622,9 +622,12 @@ a {
     }
 
     .bb-circle-slider .bb-slider-content h2,
-    .bb-circle-slider .bb-slider-content > p,
-    .bb-circle-slider .bb-slider-content .bb-slider-context>div h3 {
+    .bb-circle-slider .bb-slider-content > p {
         text-align: center;
+    }
+
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div h3 {
+        text-align: left;
     }
 
     .bb-circle-slider .bb-slider-content p a {

--- a/assets/global.js
+++ b/assets/global.js
@@ -138,6 +138,13 @@ jQuery(function ($) {
     // Initialize animation state
     let isAnimating = false;
 
+    function resetFaq() {
+        $('.bb-faq-description').stop(true, true).slideUp(200).removeClass('active');
+        $('.bb-faq-icon').each(function(){
+            $(this).attr('src', $(this).data('add'));
+        });
+    }
+
     $('.bb-downarrow').on('click', function (e) {
         e.preventDefault();
         const wrapper = $(this).closest('.d-flex.justify-content-between');
@@ -145,18 +152,11 @@ jQuery(function ($) {
         const icon = $(this).find('.bb-faq-icon');
 
         if (desc.hasClass('active')) {
-            $('.bb-faq-description').slideUp(100).removeClass('active');
-            $('.bb-faq-icon').each(function(){
-                $(this).attr('src', $(this).data('add'));
-            });
+            resetFaq();
         } else {
-            $('.bb-faq-description').slideUp(100).removeClass('active');
-            $('.bb-faq-icon').each(function(){
-                $(this).attr('src', $(this).data('add'));
-            });
-            desc.slideToggle(300).addClass('active');
+            resetFaq();
+            desc.stop(true, true).slideDown(300).addClass('active');
             icon.attr('src', icon.data('subtract'));
-            return;
         }
     })
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -140,16 +140,24 @@ jQuery(function ($) {
 
     $('.bb-downarrow').on('click', function (e) {
         e.preventDefault();
-        if ($(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').hasClass('active')) {
-            $('.bb-faq-description').slideUp(100)
-            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').removeClass('active')
-        } else {
-            $('.bb-faq-title').find('.bb-faq-description').removeClass('active')
-            $('.bb-faq-description').slideUp(100)
-            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').slideToggle(300)
-            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').addClass('active')
-        }
+        const wrapper = $(this).closest('.d-flex.justify-content-between');
+        const desc = wrapper.next('.bb-faq-description');
+        const icon = $(this).find('.bb-faq-icon');
 
+        if (desc.hasClass('active')) {
+            $('.bb-faq-description').slideUp(100).removeClass('active');
+            $('.bb-faq-icon').each(function(){
+                $(this).attr('src', $(this).data('add'));
+            });
+        } else {
+            $('.bb-faq-description').slideUp(100).removeClass('active');
+            $('.bb-faq-icon').each(function(){
+                $(this).attr('src', $(this).data('add'));
+            });
+            desc.slideToggle(300).addClass('active');
+            icon.attr('src', icon.data('subtract'));
+            return;
+        }
     })
 
     const sliderSection = $('.bb-circle-slider').first();

--- a/blocks/faq/faq.php
+++ b/blocks/faq/faq.php
@@ -16,8 +16,7 @@ $faq_items = get_field('faq_items');
                            <?php echo wp_kses_post($faq['question']); ?>
                             <div>
                                 <button type="button" class="bb-faq-toggle">
-                                    <img class="d-none d-lg-block" src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/downarrow.png" alt="Toggle answer">
-                                    <img class="d-block d-lg-none" src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/add.png" alt="Toggle answer">
+                                    <img class="bb-faq-icon" src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/add.png" data-add="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/add.png" data-subtract="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/subtract.png" alt="Toggle answer">
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- update FAQ markup to use plus/minus icons
- toggle FAQ icons in JS when sections open/close
- keep circle slider step titles left-aligned on mobile

## Testing
- `php -l blocks/faq/faq.php`
- `node -c assets/global.js`


------
https://chatgpt.com/codex/tasks/task_e_6889f64e8a388325b1bd747b5d7168e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text alignment for slider headings to improve visual consistency.
* **Bug Fixes**
  * Improved FAQ toggle behavior to ensure icons consistently update when expanding or collapsing answers.
* **Refactor**
  * Consolidated FAQ toggle icons into a single image per item, with dynamic switching for improved responsiveness and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->