### PR TITLE
Update FAQ icons, smooth animations

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -394,6 +394,11 @@ a {
     text-decoration: underline !important;
 }
 
+.bb-faq-icon {
+    width: 24px;
+    height: 24px;
+}
+
 .bb-circle-slider {
     background-color: var(--background);
 }
@@ -622,9 +627,12 @@ a {
     }
 
     .bb-circle-slider .bb-slider-content h2,
-    .bb-circle-slider .bb-slider-content > p,
-    .bb-circle-slider .bb-slider-content .bb-slider-context>div h3 {
+    .bb-circle-slider .bb-slider-content > p {
         text-align: center;
+    }
+
+    .bb-circle-slider .bb-slider-content .bb-slider-context>div h3 {
+        text-align: left;
     }
 
     .bb-circle-slider .bb-slider-content p a {

--- a/assets/global.js
+++ b/assets/global.js
@@ -138,18 +138,27 @@ jQuery(function ($) {
     // Initialize animation state
     let isAnimating = false;
 
+    function resetFaq(exceptDesc) {
+        $('.bb-faq-description').not(exceptDesc).stop(true, true)
+            .slideUp(200).removeClass('active');
+        $('.bb-faq-icon').each(function(){
+            $(this).attr('src', $(this).data('add'));
+        });
+    }
+
     $('.bb-downarrow').on('click', function (e) {
         e.preventDefault();
-        if ($(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').hasClass('active')) {
-            $('.bb-faq-description').slideUp(100)
-            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').removeClass('active')
-        } else {
-            $('.bb-faq-title').find('.bb-faq-description').removeClass('active')
-            $('.bb-faq-description').slideUp(100)
-            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').slideToggle(300)
-            $(this).closest('.d-flex.justify-content-between').next('.bb-faq-description').addClass('active')
-        }
+        const desc = $(this).next('.bb-faq-description');
+        const icon = $(this).find('.bb-faq-icon');
 
+        if (desc.hasClass('active')) {
+            desc.stop(true, true).slideUp(200).removeClass('active');
+            icon.attr('src', icon.data('add'));
+        } else {
+            resetFaq(desc);
+            desc.stop(true, true).slideDown(300).addClass('active');
+            icon.attr('src', icon.data('subtract'));
+        }
     })
 
     const sliderSection = $('.bb-circle-slider').first();

--- a/blocks/faq/faq.php
+++ b/blocks/faq/faq.php
@@ -16,8 +16,7 @@ $faq_items = get_field('faq_items');
                            <?php echo wp_kses_post($faq['question']); ?>
                             <div>
                                 <button type="button" class="bb-faq-toggle">
-                                    <img class="d-none d-lg-block" src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/downarrow.png" alt="Toggle answer">
-                                    <img class="d-block d-lg-none" src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/add.png" alt="Toggle answer">
+                                    <img class="bb-faq-icon" src="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/add.png" data-add="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/add.png" data-subtract="<?php echo plugin_dir_url(__FILE__); ?>../../assets/images/subtract.png" alt="Toggle answer">
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- size FAQ plus/minus icons to 24px
- improve FAQ toggling to avoid jumpiness

## Testing
- `php -l blocks/faq/faq.php`
- `node --check assets/global.js`


------
https://chatgpt.com/codex/tasks/task_e_6889f64e8a388325b1bd747b5d7168e3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new FAQ icon style for consistent sizing.
  * Improved FAQ toggle behavior with smoother animations and more reliable icon updates.

* **Refactor**
  * Consolidated FAQ toggle icons into a single image element for better maintainability and responsiveness.
  * Adjusted text alignment for FAQ slider content on smaller screens for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->