### PR TITLE
Fix FAQ layout shifts and improve font loading

### DIFF
--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -42,16 +42,24 @@ add_action( 'wp_enqueue_scripts', function () {
 
 	// Plugin JS
 	$js = plugin_dir_path( __FILE__ ) . 'assets/global.js';
-	if ( file_exists( $js ) ) {
-		wp_enqueue_script(
-			'bigboost-global',
-			plugin_dir_url( __FILE__ ) . 'assets/global.js',
-			[ 'jquery' ],
-			filemtime( $js ),
-			true
-		);
-	}
+        if ( file_exists( $js ) ) {
+                wp_enqueue_script(
+                        'bigboost-global',
+                        plugin_dir_url( __FILE__ ) . 'assets/global.js',
+                        [ 'jquery' ],
+                        filemtime( $js ),
+                        true
+                );
+        }
 } );
+
+// Preload fonts early to prevent layout shifts on FAQ toggle
+add_action( 'wp_head', function () {
+        $font_url = plugin_dir_url( __FILE__ ) . 'assets/fonts/';
+        echo '<link rel="preload" href="' . esc_url( $font_url . 'GoFundMeSans-Regular.woff2' ) . '" as="font" type="font/woff2" crossorigin>' . "\n";
+        echo '<link rel="preload" href="' . esc_url( $font_url . 'GoFundMeSans-Medium.woff2' ) . '" as="font" type="font/woff2" crossorigin>' . "\n";
+        echo '<link rel="preload" href="' . esc_url( $font_url . 'GoFundMeSans-Bold.woff2' ) . '" as="font" type="font/woff2" crossorigin>' . "\n";
+}, 1 );
 
 /*--------------------------------------------------------------
  # 2.  ACF JSON sync

--- a/assets/global.css
+++ b/assets/global.css
@@ -290,7 +290,8 @@ a {
 .bb-faq-section>div>span {
     font-weight: 700;
     font-size: 28px;
-    font-family: 'GoFundMe';
+    font-family: 'GoFundMe', system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.5;
 }
 
 .bb-faq-section .bb-faq-title {
@@ -313,14 +314,15 @@ a {
     color: var(--primary);
     font-weight: 700;
     font-size: 40px;
-    font-family: 'GoFundMe';
+    font-family: 'GoFundMe', system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.2;
 }
 
 .bb-faq-section .bb-faq-title p {
     font-weight: 400;
     font-size: 24px;
-    font-family: 'GoFundMe';
-    line-height: 150%;
+    font-family: 'GoFundMe', system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.5;
     letter-spacing: 0px;
     color: var(--secondary);
 }
@@ -387,6 +389,21 @@ a {
 .bb-faq-title .bb-faq-description {
     display: none;
     color: #6F6F6F;
+    overflow: hidden;
+    contain: layout paint;
+    will-change: height;
+    font-family: 'GoFundMe', system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    line-height: 1.5;
+}
+
+/* Optional CSS-only toggle */
+.bb-faq-title .bb-faq-description.css-toggle {
+    display: block;
+    max-height: 0;
+    transition: max-height 0.3s ease;
+}
+.bb-faq-title .bb-faq-description.css-toggle.active {
+    max-height: 1000px;
 }
 
 .bb-faq-title .bb-faq-description a {

--- a/assets/global.js
+++ b/assets/global.js
@@ -146,10 +146,10 @@ $('.bb-downarrow').on('click', function (e) {
     const icon = $(this).find('.bb-faq-icon');
 
     if (desc.hasClass('active')) {
-        desc.slideUp(200).removeClass('active');
+        desc.stop(true, true).slideUp(200).removeClass('active');
         icon.attr('src', icon.data('add'));
     } else {
-        $('.bb-faq-description.active').not(desc).slideUp(200).removeClass('active');
+        $('.bb-faq-description.active').not(desc).stop(true, true).slideUp(200).removeClass('active');
         $('.bb-faq-icon').not(icon).attr('src', function(){ return $(this).data('add'); });
         desc.stop(true, true).slideDown(300).addClass('active');
         icon.attr('src', icon.data('subtract'));


### PR DESCRIPTION
## Summary
- preload GoFundMe fonts in the head to avoid janky swaps
- make FAQ fonts use a fallback stack and unitless line height
- isolate FAQ description reflow
- stop jQuery animation queues when toggling FAQ items
- add optional CSS-only FAQ toggle style

## Testing
- `php -l acf-custom-blocks.php`
- `node --check assets/global.js`

------
https://chatgpt.com/codex/tasks/task_e_688a0da00dac83258af9f63562587916