### PR TITLE
Adjust hero and CTA styles

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -172,6 +172,14 @@ a {
     font-family: 'GoFundMe';
     font-weight: 700;
     padding: 20px 0;
+    max-width: 1014px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.hero-section h2 {
+    max-width: 1014px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 @media (max-width: 992px) {
@@ -275,12 +283,18 @@ a {
     color: var(--green);
     font-size: 24px;
     font-family: 'GoFundMe';
-    font-weight: 500;
+    font-weight: 700;
     padding: 8px 24px;
     border-radius: 100px;
     display: block;
     width: fit-content;
     margin: 0 auto;
+    text-align: center;
+}
+
+.primary-button:hover {
+    background-color: #E9FCCE;
+    color: var(--green);
 }
 
 .bb-faq-section {
@@ -330,7 +344,7 @@ a {
 .survey {
     padding: 100px 0;
     background-color: #DAF4F4;
-    clip-path: ellipse(100% 100% at 50% 0%);
+    clip-path: ellipse(100% 100% at 50% 100%);
 }
 
 .survey h2 {
@@ -358,7 +372,7 @@ a {
 }
 
 .survey a {
-    background-color: var(--green);
+    background-color: #1C456B;
     display: block;
     padding: 8px 24px;
     width: fit-content;
@@ -367,14 +381,14 @@ a {
     line-height: 150%;
     letter-spacing: 0px;
     text-align: center;
-    color: var(--yellow);
+    color: #A7E3E3;
     border-radius: 50px;
     margin: 0 auto;
     font-weight: 700;
 }
 
 .survey a:hover {
-    color: var(--yellow);
+    color: #A7E3E3;
 }
 
 .bb-faq-title h2 {
@@ -447,6 +461,10 @@ a {
     font-size: 14px !important;
     font-weight: 400;
     font-family: 'GoFundMe';
+}
+.bb-circle-slider .bb-slider-context p {
+    font-size: 16px;
+    font-weight: 400;
 }
 
 .bb-circle-slider .bb-slider-content .bb-border-view {

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,7 +1,7 @@
 jQuery(function ($) {
 
     const DURATION = 7000; // ms – keep in sync with CSS & autoplay
-    const PROGRESS_RADIUS = 24;
+    const PROGRESS_RADIUS = 23;
     const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
 
     let height = $('.bb-slider-content').outerHeight();

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -29,7 +29,7 @@ $section_items = get_field('field_circle_slider_items');
                                         <div>
                                             <div class="bb-circle-outline">
                                                 <svg class="progress-ring" viewBox="0 0 50 50">
-                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
+                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="23"></circle>
                                                 </svg>
                                                 <span><?php echo esc_html($item['step_number']); ?></span>
                                             </div>
@@ -88,7 +88,7 @@ $section_items = get_field('field_circle_slider_items');
                                         <div>
                                             <div class="bb-circle-outline">
                                                 <svg class="progress-ring" viewBox="0 0 50 50">
-                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
+                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="23"></circle>
                                                 </svg>
                                                 <span> <?php echo esc_html($item['step_number']); ?> </span>
                                             </div>


### PR DESCRIPTION
## Summary
- ensure banner headings stay within 1014px
- bold banner button and tweak hover color
- correct circle slider progress radius
- keep slider sub copy at 16px
- arch top of CTA and recolor button

## Testing
- `php -l blocks/circle-slider/circle-slider.php`
- `find blocks -name '*.php' -print | xargs -I {} php -l {}`
- `php -l acf-custom-blocks.php`
- `node -e "console.log('test')"`


------
https://chatgpt.com/codex/tasks/task_e_688a5418097883258e0a842946654ec4