### PR TITLE
Fix mobile CTA and quote image

### DIFF
--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -161,7 +161,7 @@ add_action( 'acf/init', function () {
                     'label'         => 'Mobile CTA URL',
                     'name'          => 'mobile_cta_url',
                     'type'          => 'url',
-                    'default_value' => 'https://www.gfm-test01.com/create/fundraiser/category',
+                    'default_value' => home_url( '/create/fundraiser/category' ),
                 ],
             ],
             'location' => [ [ [ 'param' => 'options_page', 'operator' => '==', 'value' => 'theme-settings' ] ] ],

--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -161,7 +161,7 @@ add_action( 'acf/init', function () {
                     'label'         => 'Mobile CTA URL',
                     'name'          => 'mobile_cta_url',
                     'type'          => 'url',
-                    'default_value' => 'https://www.gofundme.com/start',
+                    'default_value' => 'https://www.gfm-test01.com/create/fundraiser/category',
                 ],
             ],
             'location' => [ [ [ 'param' => 'options_page', 'operator' => '==', 'value' => 'theme-settings' ] ] ],

--- a/assets/global.css
+++ b/assets/global.css
@@ -648,7 +648,7 @@ a {
 @media (max-width: 768px) {
         .hero-quote-img{
                 padding-bottom:20px !important;
-                margin-top:-100px;
+                margin-top:0;
         }
         .hero-section{
                 padding-top:65px;
@@ -884,6 +884,7 @@ cite::before {
         bottom: 0;
         left: 50%;
         transform: translateX(-50%);
+        display: block;
         width: calc(100% - 2rem);
         max-width: 344px;
         background-color: #0B291A;

--- a/assets/global.css
+++ b/assets/global.css
@@ -648,7 +648,9 @@ a {
 @media (max-width: 768px) {
         .hero-quote-img{
                 padding-bottom:20px !important;
-                margin-top:0;
+                margin-top:-100px;
+                position:relative;
+                z-index:2;
         }
         .hero-section{
                 padding-top:65px;


### PR DESCRIPTION
## Summary
- tune default mobile CTA URL
- adjust mobile CTA styles to appear properly
- keep quote image inside banner on mobile

## Testing
- `php -l acf-custom-blocks.php`

------
https://chatgpt.com/codex/tasks/task_e_688a676bcf6c8325986ab6618d35df6d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default mobile call-to-action URL in Theme Settings.
  * Adjusted hero quote image spacing for mobile devices.
  * Ensured the mobile call-to-action button displays correctly on small screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->