### PR TITLE
Fix CTA container background and FAQ spacing

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -325,10 +325,11 @@ a {
 
 .bb-faq-section .bb-faq-title>div {
     border-bottom: 1px solid #D8D8D8;
+    padding: 32px 0;
 }
 
 .bb-faq-section .bb-faq-title>div:not(:last-child) {
-    margin-bottom: 32px;
+    margin-bottom: 0;
 }
 
 .bb-faq-section .bb-faq-title>div>div:first-child {
@@ -338,7 +339,7 @@ a {
 .bb-faq-section .bb-faq-title h2 {
     color: var(--primary);
     font-weight: 700;
-    font-size: 40px;
+    font-size: 40px !important;
     font-family: 'GoFundMe', system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     line-height: 1.2;
 }
@@ -377,7 +378,7 @@ a {
     line-height: 150%;
     letter-spacing: 0px;
     text-align: center;
-    color: #252525;
+    color: #1C456B;
     width: 50%;
     margin-bottom: 37px;
 }
@@ -680,6 +681,7 @@ a {
     .survey p {
         font-weight: 400;
         font-size: 14px !important;
+        color: #1C456B;
     }
 
     .bb-circle-slider .bb-slider-content {
@@ -726,6 +728,7 @@ a {
 
     .survey p {
         width: 70%;
+        color: #1C456B;
     }
 
     .quotes-section span {
@@ -746,6 +749,10 @@ a {
 
     .bb-faq-title>div>div h2 {
         width: calc(100% - 32px);
+    }
+
+    .bb-faq-title>div {
+        padding: 24px 0;
     }
 
     .bb-faq-section {
@@ -881,21 +888,27 @@ cite::before {
 }
 
 @media (max-width: 768px) {
-    .mobile-cta-button {
+    .mobile-cta-container {
         position: fixed;
         bottom: calc(1rem + env(safe-area-inset-bottom));
         left: 50%;
         transform: translateX(-50%);
-        display: block;
         width: calc(100% - 2rem);
         max-width: 344px;
+        background-color: var(--white);
+        padding: 8px;
+        border-radius: 100px;
+        z-index: 100;
+    }
+    .mobile-cta-button {
+        display: block;
+        width: 100%;
         background-color: #0B291A;
         color: #CCF88E;
         font-weight: 800;
         font-size: 16px;
         padding: 8px 0;
         text-align: center;
-        z-index: 100;
         border-radius: 100px;
     }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,7 +1,7 @@
 jQuery(function ($) {
 
     const DURATION = 7000; // ms – keep in sync with CSS & autoplay
-    const PROGRESS_RADIUS = 23;
+    const PROGRESS_RADIUS = 24;
     const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
     let height = $('.bb-slider-content').outerHeight();
     $('.bb-slider-images').height(height);

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -29,7 +29,7 @@ $section_items = get_field('field_circle_slider_items');
                                         <div>
                                             <div class="bb-circle-outline">
                                                 <svg class="progress-ring" viewBox="0 0 50 50">
-                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="23"></circle>
+                                                <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
                                                 </svg>
                                                 <span><?php echo esc_html($item['step_number']); ?></span>
                                             </div>
@@ -88,7 +88,7 @@ $section_items = get_field('field_circle_slider_items');
                                         <div>
                                             <div class="bb-circle-outline">
                                                 <svg class="progress-ring" viewBox="0 0 50 50">
-                                                    <circle class="progress-ring__circle" cx="25" cy="25" r="23"></circle>
+                                                <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
                                                 </svg>
                                                 <span> <?php echo esc_html($item['step_number']); ?> </span>
                                             </div>

--- a/blocks/floating-cta/floating-cta.php
+++ b/blocks/floating-cta/floating-cta.php
@@ -2,7 +2,9 @@
 $text = get_field('cta_text');
 $url  = get_field('cta_url');
 if ( $text && $url ) : ?>
-<a href="<?php echo esc_url( $url ); ?>" class="mobile-cta-button d-lg-none" aria-label="<?php echo esc_attr( $text ); ?>">
-    <?php echo esc_html( $text ); ?>
-</a>
+<div class="mobile-cta-container d-lg-none">
+    <a href="<?php echo esc_url( $url ); ?>" class="mobile-cta-button" aria-label="<?php echo esc_attr( $text ); ?>">
+        <?php echo esc_html( $text ); ?>
+    </a>
+</div>
 <?php endif; ?>


### PR DESCRIPTION
## Summary
- add wrapper around floating CTA and style the container with a white background
- adjust progress ring size for best practices loader
- normalize FAQ spacing and set question font size to 40px
- update survey section text color

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688c6971fa108325ba661046e24b5fa8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing, color consistency, and layout in the FAQ section and survey text.
  * Enhanced mobile call-to-action (CTA) container styling for better appearance and usability on small screens.
  * Adjusted font sizes and padding for improved readability and visual alignment.

* **Refactor**
  * Updated the structure of the mobile CTA button for better maintainability and alignment with design standards.
  * Slightly increased the radius of the circular progress indicator for a more refined look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->