### PR TITLE
Update progress ring and FAQ styles

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -333,7 +333,7 @@ a {
 }
 
 .bb-faq-section .bb-faq-title>div>div:first-child {
-    margin-bottom: 24px;
+    margin-bottom: 0;
 }
 
 .bb-faq-section .bb-faq-title h2 {
@@ -342,6 +342,7 @@ a {
     font-size: 40px !important;
     font-family: 'GoFundMe', system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     line-height: 1.2;
+    margin-bottom: 0;
 }
 
 .bb-faq-section .bb-faq-title p {
@@ -405,6 +406,7 @@ a {
 
 .bb-faq-title h2 {
     color: #333333 !important;
+    margin-bottom: 0;
 }
 
 .bb-faq-title h2 a {
@@ -500,8 +502,8 @@ a {
 
 .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline {
     border: 2px solid var(--white);
-    width: 50px;
-    height: 50px;
+    width: 52px;
+    height: 52px;
     border-radius: 50%;
     font-size: 18px;
     font-family: 'GoFundMe';
@@ -518,11 +520,11 @@ a {
 }
 
 .bb-circle-slider .bb-slider-content .bb-circle-outline .progress-ring__circle {
-    stroke: var(--yellow);
+    stroke: var(--green);
     stroke-width: 2;
     fill: none;
-    stroke-dasharray: 151;
-    stroke-dashoffset: 151;
+    stroke-dasharray: 160.22;
+    stroke-dashoffset: 160.22;
 }
 
 .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline span {
@@ -539,8 +541,8 @@ a {
 
 @media (max-width: 992px) {
     .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline {
-        width: 32px;
-        height: 32px;
+        width: 34px;
+        height: 34px;
     }
 }
 

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,7 +1,7 @@
 jQuery(function ($) {
 
     const DURATION = 7000; // ms – keep in sync with CSS & autoplay
-    const PROGRESS_RADIUS = 24;
+    const PROGRESS_RADIUS = 25.5;
     const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
     let height = $('.bb-slider-content').outerHeight();
     $('.bb-slider-images').height(height);

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -28,8 +28,8 @@ $section_items = get_field('field_circle_slider_items');
 
                                         <div>
                                             <div class="bb-circle-outline">
-                                                <svg class="progress-ring" viewBox="0 0 50 50">
-                                                <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
+                                                <svg class="progress-ring" viewBox="0 0 52 52">
+                                                <circle class="progress-ring__circle" cx="26" cy="26" r="25.5"></circle>
                                                 </svg>
                                                 <span><?php echo esc_html($item['step_number']); ?></span>
                                             </div>
@@ -87,8 +87,8 @@ $section_items = get_field('field_circle_slider_items');
                                     <button type="button" class="d-flex align-items-center bb-toggle-slider mb-3">
                                         <div>
                                             <div class="bb-circle-outline">
-                                                <svg class="progress-ring" viewBox="0 0 50 50">
-                                                <circle class="progress-ring__circle" cx="25" cy="25" r="24"></circle>
+                                                <svg class="progress-ring" viewBox="0 0 52 52">
+                                                <circle class="progress-ring__circle" cx="26" cy="26" r="25.5"></circle>
                                                 </svg>
                                                 <span> <?php echo esc_html($item['step_number']); ?> </span>
                                             </div>


### PR DESCRIPTION
## Summary
- enlarge progress ring radius and color
- adjust progress animation to match new radius
- tweak progress ring CSS for new size
- remove extra FAQ heading spacing

## Testing
- `php -l blocks/circle-slider/circle-slider.php`
- `php -l acf-custom-blocks.php`
- `php -l blocks/faq/faq.php`

------
https://chatgpt.com/codex/tasks/task_e_688c6f85aafc832581164f179cd94b99