### PR TITLE
Fix progress ring clipping

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -521,10 +521,10 @@ a {
 
 .bb-circle-slider .bb-slider-content .bb-circle-outline .progress-ring__circle {
     stroke: var(--green);
-    stroke-width: 2;
+    stroke-width: 4;
     fill: none;
-    stroke-dasharray: 160.22;
-    stroke-dashoffset: 160.22;
+    stroke-dasharray: 150.8;
+    stroke-dashoffset: 150.8;
 }
 
 .bb-circle-slider .bb-slider-content .bb-slider-context>div .bb-circle-outline span {

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,7 +1,7 @@
 jQuery(function ($) {
 
     const DURATION = 7000; // ms – keep in sync with CSS & autoplay
-    const PROGRESS_RADIUS = 25.5;
+    const PROGRESS_RADIUS = 24;
     const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
     let height = $('.bb-slider-content').outerHeight();
     $('.bb-slider-images').height(height);

--- a/blocks/circle-slider/circle-slider.php
+++ b/blocks/circle-slider/circle-slider.php
@@ -29,7 +29,7 @@ $section_items = get_field('field_circle_slider_items');
                                         <div>
                                             <div class="bb-circle-outline">
                                                 <svg class="progress-ring" viewBox="0 0 52 52">
-                                                <circle class="progress-ring__circle" cx="26" cy="26" r="25.5"></circle>
+                                                <circle class="progress-ring__circle" cx="26" cy="26" r="24"></circle>
                                                 </svg>
                                                 <span><?php echo esc_html($item['step_number']); ?></span>
                                             </div>
@@ -88,7 +88,7 @@ $section_items = get_field('field_circle_slider_items');
                                         <div>
                                             <div class="bb-circle-outline">
                                                 <svg class="progress-ring" viewBox="0 0 52 52">
-                                                <circle class="progress-ring__circle" cx="26" cy="26" r="25.5"></circle>
+                                                <circle class="progress-ring__circle" cx="26" cy="26" r="24"></circle>
                                                 </svg>
                                                 <span> <?php echo esc_html($item['step_number']); ?> </span>
                                             </div>


### PR DESCRIPTION
## Summary
- thicken progress ring stroke
- reduce circle radius for stroke thickness
- keep circumference calculations in sync

## Testing
- `npm test` *(fails: could not find package.json)*
- `composer test` *(fails: command not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688c74f545b08325965595d7b9b8ea46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the thickness and adjusted the dash pattern of the circular progress ring in the slider for a refreshed appearance.

* **Refactor**
  * Updated the size and radius of the circular progress indicator to improve visual consistency across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->