### PR TITLE
Fix progress ring and CTA styles

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -911,14 +911,11 @@ cite::before {
 @media (max-width: 768px) {
     .mobile-cta-container {
         position: fixed;
-        bottom: calc(1rem + env(safe-area-inset-bottom));
-        left: 50%;
-        transform: translateX(-50%);
-        width: calc(100% - 2rem);
-        max-width: 344px;
+        bottom: 0;
+        left: 0;
+        width: 100%;
         background-color: var(--white);
         padding: 8px;
-        border-radius: 100px;
         z-index: 100;
     }
     .mobile-cta-button {
@@ -930,7 +927,6 @@ cite::before {
         font-size: 16px;
         padding: 8px 0;
         text-align: center;
-        border-radius: 100px;
     }
     .bb-faq-section .bb-faq-title h2 {
         font-size: 28px !important;

--- a/assets/global.js
+++ b/assets/global.js
@@ -1,8 +1,10 @@
+// Shared constants for circle progress animations
+const PROGRESS_RADIUS = 24;
+const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
+
 jQuery(function ($) {
 
     const DURATION = 7000; // ms – keep in sync with CSS & autoplay
-    const PROGRESS_RADIUS = 24;
-    const PROGRESS_CIRCUMFERENCE = 2 * Math.PI * PROGRESS_RADIUS;
     let height = $('.bb-slider-content').outerHeight();
     $('.bb-slider-images').height(height);
     let previousIndex = 0;


### PR DESCRIPTION
## Summary
- expose progress ring constants globally
- make mobile CTA span full width at bottom

## Testing
- `php -l blocks/gallery/gallery.php`
- `php -l blocks/circle-slider/circle-slider.php`
- `php -l blocks/faq/faq.php`
- `php -l blocks/floating-cta/floating-cta.php`
- `php -l blocks/quote-section/quote.php`
- `php -l blocks/call-to-action/cta.php`
- `php -l blocks/banner-section/banner.php`
- `php -l acf-custom-blocks.php`


------
https://chatgpt.com/codex/tasks/task_e_688d02e034b0832580dfbed88e9216b7