### PR TITLE
Add desktop and mobile variants for quote text

### DIFF
--- a/assets/global.css
+++ b/assets/global.css
@@ -965,3 +965,25 @@ cite::before {
     font-size: 18px;
   }
 }
+
+.quotes-section p.quote-desktop {
+  display: block;
+  font-size: 26px;
+  font-weight: 300;
+}
+
+.quotes-section p.quote-mobile {
+  display: none;
+  font-size: 18px;
+  font-weight: 300;
+}
+
+@media (max-width: 480px) {
+  .quotes-section p.quote-desktop {
+    display: none;
+  }
+
+  .quotes-section p.quote-mobile {
+    display: block;
+  }
+}

--- a/blocks/quote-section/quote.php
+++ b/blocks/quote-section/quote.php
@@ -16,7 +16,8 @@
       </div>
       <div class="col-12 col-md-6 quotes-blocks">
         <blockquote class="quote-line">
-          <?php echo apply_filters('the_content', $quote); ?>
+          <p class="quote-desktop"><?php echo esc_html($quote); ?></p>
+          <p class="quote-mobile"><?php echo esc_html($quote); ?></p>
         </blockquote>
         <cite class="quote-author">
          <?php echo esc_html($author); ?>


### PR DESCRIPTION
## Summary
- duplicate quote paragraph for mobile and desktop
- style desktop and mobile quote blocks and toggle visibility by screen size

## Testing
- `php -l blocks/quote-section/quote.php`

------
https://chatgpt.com/codex/tasks/task_e_688d23c62750832591dc8c978454932a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced separate quote displays for desktop and mobile, ensuring optimal readability on different devices.

* **Style**
  * Updated styles to show larger quotes on desktop and more compact quotes on mobile screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->