### PR TITLE
Add Giving Funds CTA block

### DIFF
--- a/acf-custom-blocks.php
+++ b/acf-custom-blocks.php
@@ -102,15 +102,16 @@ add_filter( 'allowed_block_types_all', function ( $allowed, $ctx ) {
 		return $allowed;
 	}
 
-	$custom = [
-		'acf/banner-section',
-		'acf/quote-section',
+        $custom = [
+                'acf/banner-section',
+                'acf/quote-section',
                 'acf/call-to-action',
                 'acf/floating-cta',
                 'acf/gallery',
-		'acf/faq',
-        'acf/circle-slider',
-	];
+                'acf/faq',
+                'acf/circle-slider',
+                'acf/giving-funds-cta',
+        ];
 
 	if ( ! is_array( $allowed ) ) {
 		return true;
@@ -315,6 +316,27 @@ add_action( 'acf/init', function () {
                 ),
             ),
         ));
+
+        // Giving Funds CTA Block
+        acf_add_local_field_group( [
+                'key'    => 'group_giving_funds_cta',
+                'title'  => 'Giving Funds CTA Block',
+                'fields' => [
+                        [ 'key' => 'field_giving_funds_subtitle',    'label' => 'Subtitle',    'name' => 'giving_funds_subtitle',    'type' => 'text' ],
+                        [ 'key' => 'field_giving_funds_title',       'label' => 'Title',       'name' => 'giving_funds_title',       'type' => 'text' ],
+                        [ 'key' => 'field_giving_funds_description', 'label' => 'Description', 'name' => 'giving_funds_description', 'type' => 'textarea' ],
+                        [ 'key' => 'field_giving_funds_button',      'label' => 'Button',      'name' => 'giving_funds_button',      'type' => 'link' ],
+                        [
+                                'key'          => 'field_giving_funds_image',
+                                'label'        => 'Image',
+                                'name'         => 'giving_funds_image',
+                                'type'         => 'image',
+                                'return_format'=> 'array',
+                                'preview_size' => 'thumbnail',
+                        ],
+                ],
+                'location' => [ [ [ 'param' => 'block', 'operator' => '==', 'value' => 'acf/giving-funds-cta' ] ] ],
+        ] );
 
 
 

--- a/assets/global.css
+++ b/assets/global.css
@@ -987,3 +987,71 @@ cite::before {
     display: block;
   }
 }
+
+/* Giving Funds CTA */
+.giving-funds-cta {
+    padding: 100px 0;
+}
+
+.giving-funds-cta__inner {
+    display: flex;
+    align-items: center;
+    gap: 40px;
+}
+
+.giving-funds-cta__text {
+    flex: 1;
+}
+
+.giving-funds-cta__image {
+    flex: 1;
+    text-align: right;
+}
+
+.giving-funds-cta__subtitle {
+    color: #2D6339;
+    font-family: 'GoFundMe', 'GoFundMe Sans', system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    font-size: 24px;
+    font-weight: 700;
+    display: block;
+}
+
+.giving-funds-cta__title {
+    color: #232323;
+    font-family: 'GoFundMe', 'GoFundMe Sans', system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    font-size: 64px;
+    font-weight: 700;
+    margin: 16px 0;
+}
+
+.giving-funds-cta__description {
+    color: #6F6F6F;
+    font-family: 'GoFundMe', 'GoFundMe Sans', system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 150%;
+    margin-bottom: 40px;
+}
+
+.giving-funds-cta__button {
+    background-color: #274A34;
+    color: #CCF88E;
+    padding: 8px 16px;
+    font-family: 'Melun TRIAL', sans-serif;
+    font-weight: 500;
+    font-size: 14px;
+    border-radius: 100px;
+    display: inline-block;
+}
+
+@media (max-width: 768px) {
+    .giving-funds-cta__inner {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .giving-funds-cta__image {
+        text-align: center;
+        margin-top: 24px;
+    }
+}

--- a/blocks/giving-funds-cta/block.json
+++ b/blocks/giving-funds-cta/block.json
@@ -1,0 +1,15 @@
+{
+  "name": "acf/giving-funds-cta",
+  "title": "Giving Funds CTA",
+  "description": "Call to action with text and image for Giving Funds.",
+  "category": "bigboost-blocks",
+  "icon": "megaphone",
+  "keywords": ["giving", "funds", "cta"],
+  "acf": {
+    "mode": "edit",
+    "supports": {
+      "mode": false
+    },
+    "renderTemplate": "giving-funds-cta.php"
+  }
+}

--- a/blocks/giving-funds-cta/giving-funds-cta.php
+++ b/blocks/giving-funds-cta/giving-funds-cta.php
@@ -1,0 +1,32 @@
+<?php
+$subtitle    = get_field('giving_funds_subtitle');
+$title       = get_field('giving_funds_title');
+$description = get_field('giving_funds_description');
+$button      = get_field('giving_funds_button');
+$image       = get_field('giving_funds_image');
+?>
+<section class="giving-funds-cta">
+    <div class="bb-container">
+        <div class="giving-funds-cta__inner">
+            <div class="giving-funds-cta__text">
+                <?php if ( $subtitle ) : ?>
+                    <span class="giving-funds-cta__subtitle"><?php echo esc_html( $subtitle ); ?></span>
+                <?php endif; ?>
+                <?php if ( $title ) : ?>
+                    <h2 class="giving-funds-cta__title"><?php echo esc_html( $title ); ?></h2>
+                <?php endif; ?>
+                <?php if ( $description ) : ?>
+                    <p class="giving-funds-cta__description"><?php echo esc_html( $description ); ?></p>
+                <?php endif; ?>
+                <?php if ( $button ) : ?>
+                    <a class="giving-funds-cta__button" href="<?php echo esc_url( $button['url'] ); ?>"<?php if ( $button['target'] ) : ?> target="<?php echo esc_attr( $button['target'] ); ?>"<?php endif; ?>><?php echo esc_html( $button['title'] ); ?></a>
+                <?php endif; ?>
+            </div>
+            <?php if ( $image ) : ?>
+                <div class="giving-funds-cta__image">
+                    <img src="<?php echo esc_url( $image['url'] ); ?>" alt="<?php echo esc_attr( $image['alt'] ); ?>">
+                </div>
+            <?php endif; ?>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
## Summary
- add Giving Funds CTA block with subtitle, title, description, button and image
- style block and register new fields and allowed block type

## Testing
- `php -l blocks/giving-funds-cta/giving-funds-cta.php`
- `php -l acf-custom-blocks.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6890caf01fc08325ab0d3ffa9d4925f0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "Giving Funds CTA" block, allowing users to add a call-to-action section with customizable text, image, and button.
  * Added dedicated styling for the new "Giving Funds CTA" block to ensure a visually appealing and responsive layout.

* **Documentation**
  * Updated block library to include details and configuration for the new "Giving Funds CTA" block.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->